### PR TITLE
add templating for activeDeadlineSeconds and backoffLimit

### DIFF
--- a/charts/kube-dump/templates/cronjob.yaml
+++ b/charts/kube-dump/templates/cronjob.yaml
@@ -8,6 +8,8 @@ spec:
   schedule: "{{ .Values.cronSchedule }}"
   jobTemplate:
     spec:
+      activeDeadlineSeconds: {{ .Values.activeDeadlineSeconds | default "" }}
+      backoffLimit: {{ .Values.backoffLimit | default "" }}
       template:
         metadata:
           {{- with .Values.podAnnotations }}
@@ -92,3 +94,4 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+


### PR DESCRIPTION
Add optional activeDeadlineSeconds and backoffLimit so a job can fail even if the job never starts or never exits.